### PR TITLE
Update android-issue.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/android-issue.md
+++ b/.github/ISSUE_TEMPLATE/android-issue.md
@@ -60,7 +60,7 @@ Edit here
 <!-- THIS SECTION IS MANDATORY. If it is not filled out correctly, your issue will be marked as invalid.
 Example:
 /device polaris (found at https://wiki.pixelexperience.org/devices/)
-/version eleven or eleven_plus (for plus version)
+/version eleven or eleven_plus (for plus version) - Usually version written by word(s) 13=thirteen, 12=twelve, ... Or you can find out by running command "adb shell getprop org.pixelexperience.version" (or inspecting "adb shell getprop" output manually)
 -->
 
 /device


### PR DESCRIPTION
- I think bot should accept the version written by either word or number (13 or thirteen)
- If it's not feasible, this clarification should help users to report successfully
- Or if there is a way to find out the exact wording (prop org.pixelexperience.version) from UI, for normal non-developer/adb user, please provide that in clarification.
- At last, bot should reflect on edited issue, if you get issue closed by bot, you should not be forced, to create completely new (usually identical) issue, just because the device/version was not provided correctly.